### PR TITLE
Removed the peer dependency of AssemblyScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -370,12 +370,12 @@
       "dev": true
     },
     "assemblyscript": {
-      "version": "0.18.14",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.14.tgz",
-      "integrity": "sha512-HdWn1iUoMc3U2PT6wFA4dvU0tGrWJSNVfQwOoNjEVxhMIOVsFP6h2K/We6Cp332XctZHVRXeiEDj8ih3KJAe4g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.3.tgz",
+      "integrity": "sha512-IfRqQ7nYDY/UzbGnRrFwKnClR1ITha6nhHGqr/3Jzwof9BdgfqANhpqTmRcKJ5o02WAmghkjQwfJqzDfnDd1VA==",
       "dev": true,
       "requires": {
-        "binaryen": "100.0.0",
+        "binaryen": "101.0.0-nightly.20210604",
         "long": "^4.0.0"
       }
     },
@@ -398,9 +398,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "100.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
-      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ==",
+      "version": "101.0.0-nightly.20210604",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-101.0.0-nightly.20210604.tgz",
+      "integrity": "sha512-aTgX1JDN8m3tTFK8g9hazJcEOdQl7mK4yVfElkKAh7q+TRUCaea4a2SMLr1z2xZL7s9N4lkrvrBblxRuEPvxWQ==",
       "dev": true
     },
     "boxen": {
@@ -2360,9 +2360,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "np": {
@@ -2994,9 +2994,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
         },
         "normalize-package-data": {
@@ -3441,9 +3441,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,9 @@
     "url": "https://github.com/torch2424/as-date/issues"
   },
   "homepage": "https://github.com/torch2424/as-date#readme",
-  "peerDependencies": {
-    "assemblyscript": "0.18.x"
-  },
   "devDependencies": {
     "@as-pect/cli": "^6.0.0",
-    "assemblyscript": "^0.18.14",
+    "assemblyscript": "^0.19.3",
     "np": "^7.4.0",
     "prettier": "2.2.1",
     "typedoc": "^0.20.30",


### PR DESCRIPTION
Now that  AssemblyScript has a [built-in date object](https://www.assemblyscript.org/stdlib/date.html#instance-members), this library can essentially be deprecated. But! For backwards compatibility, we will remove the peer dependency, as this library should work with most, if not all, future AssemblyScript versions 😄 

![Screenshot from 2021-06-21 09-58-04](https://user-images.githubusercontent.com/1448289/122800159-745b1700-d277-11eb-9c8d-8fe63d6de2d5.png)
